### PR TITLE
Update SSL URL

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,9 +51,9 @@ func (c *Client) Send(h hitType) error {
 
 	url := ""
 	if cpy.UseTLS {
-		url = "http://www.google-analytics.com/collect"
+		url = "https://www.google-analytics.com/collect"
 	} else {
-		url = "https://ssl.google-analytics.com/collect"
+		url = "http://ssl.google-analytics.com/collect"
 	}
 
 	str := v.Encode()


### PR DESCRIPTION
Accoding to latest [document](https://developers.google.com/analytics/devguides/collection/protocol/v1/reference), SSL URL is `https://www.google-analytics.com/collect`.

